### PR TITLE
Introduce C-style interface struct

### DIFF
--- a/PN532.h
+++ b/PN532.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include "PN532Interface.h"
+#include "pn532_interface.h"
 
 // PN532 Commands
 #define PN532_COMMAND_DIAGNOSE              (0x00)
@@ -127,7 +128,7 @@
 class PN532
 {
 public:
-    PN532(PN532Interface &interface);
+    PN532(pn532_interface *interface);
 
     void begin(void);
 
@@ -203,7 +204,7 @@ private:
 
     uint8_t pn532_packetbuffer[64];
 
-    PN532Interface *_interface;
+    pn532_interface *_interface;
 };
 
 #endif

--- a/PN532Interface.h
+++ b/PN532Interface.h
@@ -4,6 +4,7 @@
 #define __PN532_INTERFACE_H__
 
 #include <stdint.h>
+#include "pn532_interface.h"
 
 #define PN532_PREAMBLE                (0x00)
 #define PN532_STARTCODE1              (0x00)
@@ -23,34 +24,6 @@
 #define REVERSE_BITS_ORDER(b)         b = (b & 0xF0) >> 4 | (b & 0x0F) << 4; \
                                       b = (b & 0xCC) >> 2 | (b & 0x33) << 2; \
                                       b = (b & 0xAA) >> 1 | (b & 0x55) << 1
-
-class PN532Interface
-{
-public:
-    virtual void begin() = 0;
-    virtual void wakeup() = 0;
-
-    /**
-    * @brief    write a command and check ack
-    * @param    header  packet header
-    * @param    hlen    length of header
-    * @param    body    packet body
-    * @param    blen    length of body
-    * @return   0       success
-    *           not 0   failed
-    */
-    virtual int8_t writeCommand(const uint8_t *header, uint8_t hlen, const uint8_t *body = 0, uint8_t blen = 0) = 0;
-
-    /**
-    * @brief    read the response of a command, strip prefix and suffix
-    * @param    buf     to contain the response data
-    * @param    len     lenght to read
-    * @param    timeout max time to wait, 0 means no timeout
-    * @return   >=0     length of response without prefix and suffix
-    *           <0      failed to read response
-    */
-    virtual int16_t readResponse(uint8_t buf[], uint8_t len, uint16_t timeout = 1000) = 0;
-};
 
 #endif
 

--- a/PN532_HSU.cpp
+++ b/PN532_HSU.cpp
@@ -1,196 +1,191 @@
-
 #include "PN532_HSU.h"
 #include "PN532_debug.h"
 
+static int8_t pn532_hsu_readAckFrame(PN532_HSU *hsu);
+static int8_t pn532_hsu_receive(PN532_HSU *hsu, uint8_t *buf, int len, uint16_t timeout = PN532_HSU_READ_TIMEOUT);
 
-PN532_HSU::PN532_HSU(HardwareSerial &serial)
+void pn532_hsu_init(PN532_HSU *hsu, HardwareSerial &serial)
 {
-    _serial = &serial;
-    command = 0;
+    hsu->_serial = &serial;
+    hsu->command = 0;
+    hsu->interface.begin = pn532_hsu_begin;
+    hsu->interface.wakeup = pn532_hsu_wakeup;
+    hsu->interface.write_command = pn532_hsu_write_command;
+    hsu->interface.read_response = pn532_hsu_read_response;
+    hsu->interface.context = hsu;
 }
 
-void PN532_HSU::begin()
+void pn532_hsu_begin(void *ctx)
 {
-    _serial->begin(115200);
+    PN532_HSU *hsu = (PN532_HSU *)ctx;
+    hsu->_serial->begin(115200);
 }
 
-void PN532_HSU::wakeup()
+void pn532_hsu_wakeup(void *ctx)
 {
-    _serial->write(0x55);
-    _serial->write(0x55);
-    _serial->write(0);
-    _serial->write(0);
-    _serial->write(0);
+    PN532_HSU *hsu = (PN532_HSU *)ctx;
+    hsu->_serial->write(0x55);
+    hsu->_serial->write(0x55);
+    hsu->_serial->write(0);
+    hsu->_serial->write(0);
+    hsu->_serial->write(0);
 
-    /** dump serial buffer */
-    if(_serial->available()){
+    if (hsu->_serial->available()) {
         DMSG("Dump serial buffer: ");
     }
-    while(_serial->available()){
-        uint8_t ret = _serial->read();
+    while (hsu->_serial->available()) {
+        uint8_t ret = hsu->_serial->read();
+        DMSG_HEX(ret);
+    }
+}
+
+int8_t pn532_hsu_write_command(void *ctx, const uint8_t *header, uint8_t hlen,
+                               const uint8_t *body, uint8_t blen)
+{
+    PN532_HSU *hsu = (PN532_HSU *)ctx;
+
+    if (hsu->_serial->available()) {
+        DMSG("Dump serial buffer: ");
+    }
+    while (hsu->_serial->available()) {
+        uint8_t ret = hsu->_serial->read();
         DMSG_HEX(ret);
     }
 
-}
+    hsu->command = header[0];
 
-int8_t PN532_HSU::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen)
-{
+    hsu->_serial->write(PN532_PREAMBLE);
+    hsu->_serial->write(PN532_STARTCODE1);
+    hsu->_serial->write(PN532_STARTCODE2);
 
-    /** dump serial buffer */
-    if(_serial->available()){
-        DMSG("Dump serial buffer: ");
-    }
-    while(_serial->available()){
-        uint8_t ret = _serial->read();
-        DMSG_HEX(ret);
-    }
-
-    command = header[0];
-    
-    _serial->write(PN532_PREAMBLE);
-    _serial->write(PN532_STARTCODE1);
-    _serial->write(PN532_STARTCODE2);
-    
     uint8_t length = hlen + blen + 1;   // length of data field: TFI + DATA
-    _serial->write(length);
-    _serial->write(~length + 1);         // checksum of length
-    
-    _serial->write(PN532_HOSTTOPN532);
+    hsu->_serial->write(length);
+    hsu->_serial->write((uint8_t)(~length + 1));         // checksum of length
+
+    hsu->_serial->write(PN532_HOSTTOPN532);
     uint8_t sum = PN532_HOSTTOPN532;    // sum of TFI + DATA
 
     DMSG("\nWrite: ");
-    
-    _serial->write(header, hlen);
+
+    hsu->_serial->write(header, hlen);
     for (uint8_t i = 0; i < hlen; i++) {
         sum += header[i];
-
         DMSG_HEX(header[i]);
     }
 
-    _serial->write(body, blen);
+    hsu->_serial->write(body, blen);
     for (uint8_t i = 0; i < blen; i++) {
         sum += body[i];
-
         DMSG_HEX(body[i]);
     }
-    
-    uint8_t checksum = ~sum + 1;            // checksum of TFI + DATA
-    _serial->write(checksum);
-    _serial->write(PN532_POSTAMBLE);
 
-    return readAckFrame();
+    uint8_t checksum = (uint8_t)(~sum + 1);            // checksum of TFI + DATA
+    hsu->_serial->write(checksum);
+    hsu->_serial->write(PN532_POSTAMBLE);
+
+    return pn532_hsu_readAckFrame(hsu);
 }
 
-int16_t PN532_HSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
+int16_t pn532_hsu_read_response(void *ctx, uint8_t buf[], uint8_t len, uint16_t timeout)
 {
+    PN532_HSU *hsu = (PN532_HSU *)ctx;
     uint8_t tmp[3];
-    
+
     DMSG("\nRead:  ");
-    
-    /** Frame Preamble and Start Code */
-    if(receive(tmp, 3, timeout)<=0){
+
+    if (pn532_hsu_receive(hsu, tmp, 3, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if(0 != tmp[0] || 0!= tmp[1] || 0xFF != tmp[2]){
+    if (0 != tmp[0] || 0 != tmp[1] || 0xFF != tmp[2]) {
         DMSG("Preamble error");
         return PN532_INVALID_FRAME;
     }
-    
-    /** receive length and check */
-    uint8_t length[2];
-    if(receive(length, 2, timeout) <= 0){
+
+    uint8_t length_arr[2];
+    if (pn532_hsu_receive(hsu, length_arr, 2, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if( 0 != (uint8_t)(length[0] + length[1]) ){
+    if (0 != (uint8_t)(length_arr[0] + length_arr[1])) {
         DMSG("Length error");
         return PN532_INVALID_FRAME;
     }
-    length[0] -= 2;
-    if( length[0] > len){
+    length_arr[0] -= 2;
+    if (length_arr[0] > len) {
         return PN532_NO_SPACE;
     }
-    
-    /** receive command byte */
-    uint8_t cmd = command + 1;               // response command
-    if(receive(tmp, 2, timeout) <= 0){
+
+    uint8_t cmd = hsu->command + 1;               // response command
+    if (pn532_hsu_receive(hsu, tmp, 2, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if( PN532_PN532TOHOST != tmp[0] || cmd != tmp[1]){
+    if (PN532_PN532TOHOST != tmp[0] || cmd != tmp[1]) {
         DMSG("Command error");
         return PN532_INVALID_FRAME;
     }
-    
-    if(receive(buf, length[0], timeout) != length[0]){
+
+    if (pn532_hsu_receive(hsu, buf, length_arr[0], timeout) != length_arr[0]) {
         return PN532_TIMEOUT;
     }
     uint8_t sum = PN532_PN532TOHOST + cmd;
-    for(uint8_t i=0; i<length[0]; i++){
+    for (uint8_t i = 0; i < length_arr[0]; i++) {
         sum += buf[i];
     }
-    
-    /** checksum and postamble */
-    if(receive(tmp, 2, timeout) <= 0){
+
+    if (pn532_hsu_receive(hsu, tmp, 2, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if( 0 != (uint8_t)(sum + tmp[0]) || 0 != tmp[1] ){
+    if (0 != (uint8_t)(sum + tmp[0]) || 0 != tmp[1]) {
         DMSG("Checksum error");
         return PN532_INVALID_FRAME;
     }
-    
-    return length[0];
+
+    return length_arr[0];
 }
 
-int8_t PN532_HSU::readAckFrame()
+static int8_t pn532_hsu_readAckFrame(PN532_HSU *hsu)
 {
     const uint8_t PN532_ACK[] = {0, 0, 0xFF, 0, 0xFF, 0};
     uint8_t ackBuf[sizeof(PN532_ACK)];
-    
+
     DMSG("\nAck: ");
-    
-    if( receive(ackBuf, sizeof(PN532_ACK), PN532_ACK_WAIT_TIME) <= 0 ){
+
+    if (pn532_hsu_receive(hsu, ackBuf, sizeof(PN532_ACK), PN532_ACK_WAIT_TIME) <= 0) {
         DMSG("Timeout\n");
         return PN532_TIMEOUT;
     }
-    
-    if( memcmp(ackBuf, PN532_ACK, sizeof(PN532_ACK)) ){
+
+    if (memcmp(ackBuf, PN532_ACK, sizeof(PN532_ACK))) {
         DMSG("Invalid\n");
         return PN532_INVALID_ACK;
     }
     return 0;
 }
 
-/**
-    @brief receive data .
-    @param buf --> return value buffer.
-           len --> length expect to receive.
-           timeout --> time of reveiving
-    @retval number of received bytes, 0 means no data received.
-*/
-int8_t PN532_HSU::receive(uint8_t *buf, int len, uint16_t timeout)
+static int8_t pn532_hsu_receive(PN532_HSU *hsu, uint8_t *buf, int len, uint16_t timeout)
 {
-  int read_bytes = 0;
-  int ret;
-  unsigned long start_millis;
-  
-  while (read_bytes < len) {
-    start_millis = millis();
-    do {
-      ret = _serial->read();
-      if (ret >= 0) {
-        break;
-     }
-    } while((timeout == 0) || ((millis()- start_millis ) < timeout));
-    
-    if (ret < 0) {
-        if(read_bytes){
-            return read_bytes;
-        }else{
-            return PN532_TIMEOUT;
+    int read_bytes = 0;
+    int ret;
+    unsigned long start_millis;
+
+    while (read_bytes < len) {
+        start_millis = millis();
+        do {
+            ret = hsu->_serial->read();
+            if (ret >= 0) {
+                break;
+            }
+        } while ((timeout == 0) || ((millis() - start_millis) < timeout));
+
+        if (ret < 0) {
+            if (read_bytes) {
+                return read_bytes;
+            } else {
+                return PN532_TIMEOUT;
+            }
         }
+        buf[read_bytes] = (uint8_t)ret;
+        DMSG_HEX(ret);
+        read_bytes++;
     }
-    buf[read_bytes] = (uint8_t)ret;
-    DMSG_HEX(ret);
-    read_bytes++;
-  }
-  return read_bytes;
+    return read_bytes;
 }

--- a/PN532_HSU.h
+++ b/PN532_HSU.h
@@ -4,27 +4,22 @@
 
 #include "PN532Interface.h"
 #include "Arduino.h"
+#include "pn532_interface.h"
 
 #define PN532_HSU_DEBUG
 
 #define PN532_HSU_READ_TIMEOUT						(1000)
 
-class PN532_HSU : public PN532Interface {
-public:
-    PN532_HSU(HardwareSerial &serial);
-    
-    void begin();
-    void wakeup();
-    virtual int8_t writeCommand(const uint8_t *header, uint8_t hlen, const uint8_t *body = 0, uint8_t blen = 0);
-    int16_t readResponse(uint8_t buf[], uint8_t len, uint16_t timeout);
-    
-private:
+typedef struct {
+    pn532_interface interface;
     HardwareSerial* _serial;
     uint8_t command;
-    
-    int8_t readAckFrame();
-    
-    int8_t receive(uint8_t *buf, int len, uint16_t timeout=PN532_HSU_READ_TIMEOUT);
-};
+} PN532_HSU;
+
+void pn532_hsu_init(PN532_HSU *hsu, HardwareSerial &serial);
+void pn532_hsu_begin(void *ctx);
+void pn532_hsu_wakeup(void *ctx);
+int8_t pn532_hsu_write_command(void *ctx, const uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen);
+int16_t pn532_hsu_read_response(void *ctx, uint8_t buf[], uint8_t len, uint16_t timeout);
 
 #endif

--- a/PN532_SWHSU.cpp
+++ b/PN532_SWHSU.cpp
@@ -1,196 +1,191 @@
-
 #include "PN532_SWHSU.h"
 #include "PN532_debug.h"
 
+static int8_t pn532_swhsu_readAckFrame(PN532_SWHSU *swhsu);
+static int8_t pn532_swhsu_receive(PN532_SWHSU *swhsu, uint8_t *buf, int len, uint16_t timeout = PN532_SWHSU_READ_TIMEOUT);
 
-PN532_SWHSU::PN532_SWHSU(SoftwareSerial &serial)
+void pn532_swhsu_init(PN532_SWHSU *swhsu, SoftwareSerial &serial)
 {
-    _serial = &serial;
-    command = 0;
+    swhsu->_serial = &serial;
+    swhsu->command = 0;
+    swhsu->interface.begin = pn532_swhsu_begin;
+    swhsu->interface.wakeup = pn532_swhsu_wakeup;
+    swhsu->interface.write_command = pn532_swhsu_write_command;
+    swhsu->interface.read_response = pn532_swhsu_read_response;
+    swhsu->interface.context = swhsu;
 }
 
-void PN532_SWHSU::begin()
+void pn532_swhsu_begin(void *ctx)
 {
-    _serial->begin(115200);
+    PN532_SWHSU *swhsu = (PN532_SWHSU *)ctx;
+    swhsu->_serial->begin(115200);
 }
 
-void PN532_SWHSU::wakeup()
+void pn532_swhsu_wakeup(void *ctx)
 {
-    _serial->write(0x55);
-    _serial->write(0x55);
-    _serial->write((uint8_t) 0);
-    _serial->write((uint8_t) 0);
-    _serial->write((uint8_t) 0);
+    PN532_SWHSU *swhsu = (PN532_SWHSU *)ctx;
+    swhsu->_serial->write((uint8_t)0x55);
+    swhsu->_serial->write((uint8_t)0x55);
+    swhsu->_serial->write((uint8_t)0);
+    swhsu->_serial->write((uint8_t)0);
+    swhsu->_serial->write((uint8_t)0);
 
-    /** dump serial buffer */
-    if(_serial->available()){
+    if (swhsu->_serial->available()) {
         DMSG("Dump serial buffer: ");
     }
-    while(_serial->available()){
-        uint8_t ret = _serial->read();
+    while (swhsu->_serial->available()) {
+        uint8_t ret = swhsu->_serial->read();
+        DMSG_HEX(ret);
+    }
+}
+
+int8_t pn532_swhsu_write_command(void *ctx, const uint8_t *header, uint8_t hlen,
+                                 const uint8_t *body, uint8_t blen)
+{
+    PN532_SWHSU *swhsu = (PN532_SWHSU *)ctx;
+
+    if (swhsu->_serial->available()) {
+        DMSG("Dump serial buffer: ");
+    }
+    while (swhsu->_serial->available()) {
+        uint8_t ret = swhsu->_serial->read();
         DMSG_HEX(ret);
     }
 
-}
+    swhsu->command = header[0];
 
-int8_t PN532_SWHSU::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen)
-{
+    swhsu->_serial->write((uint8_t)PN532_PREAMBLE);
+    swhsu->_serial->write((uint8_t)PN532_STARTCODE1);
+    swhsu->_serial->write((uint8_t)PN532_STARTCODE2);
 
-    /** dump serial buffer */
-    if(_serial->available()){
-        DMSG("Dump serial buffer: ");
-    }
-    while(_serial->available()){
-        uint8_t ret = _serial->read();
-        DMSG_HEX(ret);
-    }
-
-    command = header[0];
-    
-    _serial->write((uint8_t) PN532_PREAMBLE);
-    _serial->write((uint8_t) PN532_STARTCODE1);
-    _serial->write((uint8_t) PN532_STARTCODE2);
-    
     uint8_t length = hlen + blen + 1;   // length of data field: TFI + DATA
-    _serial->write(length);
-    _serial->write(~length + 1);         // checksum of length
-    
-    _serial->write((uint8_t) PN532_HOSTTOPN532);
+    swhsu->_serial->write(length);
+    swhsu->_serial->write((uint8_t)(~length + 1));
+
+    swhsu->_serial->write((uint8_t)PN532_HOSTTOPN532);
     uint8_t sum = PN532_HOSTTOPN532;    // sum of TFI + DATA
 
     DMSG("\nWrite: ");
-    
-    _serial->write(header, hlen);
+
+    swhsu->_serial->write(header, hlen);
     for (uint8_t i = 0; i < hlen; i++) {
         sum += header[i];
-
         DMSG_HEX(header[i]);
     }
 
-    _serial->write(body, blen);
+    swhsu->_serial->write(body, blen);
     for (uint8_t i = 0; i < blen; i++) {
         sum += body[i];
-
         DMSG_HEX(body[i]);
     }
-    
-    uint8_t checksum = ~sum + 1;            // checksum of TFI + DATA
-    _serial->write(checksum);
-    _serial->write((uint8_t) PN532_POSTAMBLE);
 
-    return readAckFrame();
+    uint8_t checksum = (uint8_t)(~sum + 1);
+    swhsu->_serial->write(checksum);
+    swhsu->_serial->write((uint8_t)PN532_POSTAMBLE);
+
+    return pn532_swhsu_readAckFrame(swhsu);
 }
 
-int16_t PN532_SWHSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
+int16_t pn532_swhsu_read_response(void *ctx, uint8_t buf[], uint8_t len, uint16_t timeout)
 {
+    PN532_SWHSU *swhsu = (PN532_SWHSU *)ctx;
     uint8_t tmp[3];
-    
+
     DMSG("\nRead:  ");
-    
-    /** Frame Preamble and Start Code */
-    if(receive(tmp, 3, timeout)<=0){
+
+    if (pn532_swhsu_receive(swhsu, tmp, 3, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if(0 != tmp[0] || 0!= tmp[1] || 0xFF != tmp[2]){
+    if (0 != tmp[0] || 0 != tmp[1] || 0xFF != tmp[2]) {
         DMSG("Preamble error");
         return PN532_INVALID_FRAME;
     }
-    
-    /** receive length and check */
-    uint8_t length[2];
-    if(receive(length, 2, timeout) <= 0){
+
+    uint8_t length_arr[2];
+    if (pn532_swhsu_receive(swhsu, length_arr, 2, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if( 0 != (uint8_t)(length[0] + length[1]) ){
+    if (0 != (uint8_t)(length_arr[0] + length_arr[1])) {
         DMSG("Length error");
         return PN532_INVALID_FRAME;
     }
-    length[0] -= 2;
-    if( length[0] > len){
+    length_arr[0] -= 2;
+    if (length_arr[0] > len) {
         return PN532_NO_SPACE;
     }
-    
-    /** receive command byte */
-    uint8_t cmd = command + 1;               // response command
-    if(receive(tmp, 2, timeout) <= 0){
+
+    uint8_t cmd = swhsu->command + 1;               // response command
+    if (pn532_swhsu_receive(swhsu, tmp, 2, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if( PN532_PN532TOHOST != tmp[0] || cmd != tmp[1]){
+    if (PN532_PN532TOHOST != tmp[0] || cmd != tmp[1]) {
         DMSG("Command error");
         return PN532_INVALID_FRAME;
     }
-    
-    if(receive(buf, length[0], timeout) != length[0]){
+
+    if (pn532_swhsu_receive(swhsu, buf, length_arr[0], timeout) != length_arr[0]) {
         return PN532_TIMEOUT;
     }
     uint8_t sum = PN532_PN532TOHOST + cmd;
-    for(uint8_t i=0; i<length[0]; i++){
+    for (uint8_t i = 0; i < length_arr[0]; i++) {
         sum += buf[i];
     }
-    
-    /** checksum and postamble */
-    if(receive(tmp, 2, timeout) <= 0){
+
+    if (pn532_swhsu_receive(swhsu, tmp, 2, timeout) <= 0) {
         return PN532_TIMEOUT;
     }
-    if( 0 != (uint8_t)(sum + tmp[0]) || 0 != tmp[1] ){
+    if (0 != (uint8_t)(sum + tmp[0]) || 0 != tmp[1]) {
         DMSG("Checksum error");
         return PN532_INVALID_FRAME;
     }
-    
-    return length[0];
+
+    return length_arr[0];
 }
 
-int8_t PN532_SWHSU::readAckFrame()
+static int8_t pn532_swhsu_readAckFrame(PN532_SWHSU *swhsu)
 {
     const uint8_t PN532_ACK[] = {0, 0, 0xFF, 0, 0xFF, 0};
     uint8_t ackBuf[sizeof(PN532_ACK)];
-    
+
     DMSG("\nAck: ");
-    
-    if( receive(ackBuf, sizeof(PN532_ACK), PN532_ACK_WAIT_TIME) <= 0 ){
+
+    if (pn532_swhsu_receive(swhsu, ackBuf, sizeof(PN532_ACK), PN532_ACK_WAIT_TIME) <= 0) {
         DMSG("Timeout\n");
         return PN532_TIMEOUT;
     }
-    
-    if( memcmp(ackBuf, PN532_ACK, sizeof(PN532_ACK)) ){
+
+    if (memcmp(ackBuf, PN532_ACK, sizeof(PN532_ACK))) {
         DMSG("Invalid\n");
         return PN532_INVALID_ACK;
     }
     return 0;
 }
 
-/**
-    @brief receive data .
-    @param buf --> return value buffer.
-           len --> length expect to receive.
-           timeout --> time of reveiving
-    @retval number of received bytes, 0 means no data received.
-*/
-int8_t PN532_SWHSU::receive(uint8_t *buf, int len, uint16_t timeout)
+static int8_t pn532_swhsu_receive(PN532_SWHSU *swhsu, uint8_t *buf, int len, uint16_t timeout)
 {
-  int read_bytes = 0;
-  int ret;
-  unsigned long start_millis;
-  
-  while (read_bytes < len) {
-    start_millis = millis();
-    do {
-      ret = _serial->read();
-      if (ret >= 0) {
-        break;
-     }
-    } while((timeout == 0) || ((millis()- start_millis ) < timeout));
-    
-    if (ret < 0) {
-        if(read_bytes){
-            return read_bytes;
-        }else{
-            return PN532_TIMEOUT;
+    int read_bytes = 0;
+    int ret;
+    unsigned long start_millis;
+
+    while (read_bytes < len) {
+        start_millis = millis();
+        do {
+            ret = swhsu->_serial->read();
+            if (ret >= 0) {
+                break;
+            }
+        } while ((timeout == 0) || ((millis() - start_millis) < timeout));
+
+        if (ret < 0) {
+            if (read_bytes) {
+                return read_bytes;
+            } else {
+                return PN532_TIMEOUT;
+            }
         }
+        buf[read_bytes] = (uint8_t)ret;
+        DMSG_HEX(ret);
+        read_bytes++;
     }
-    buf[read_bytes] = (uint8_t)ret;
-    DMSG_HEX(ret);
-    read_bytes++;
-  }
-  return read_bytes;
+    return read_bytes;
 }

--- a/PN532_SWHSU.h
+++ b/PN532_SWHSU.h
@@ -6,27 +6,22 @@
 
 #include "PN532Interface.h"
 #include "Arduino.h"
+#include "pn532_interface.h"
 
 #define PN532_SWHSU_DEBUG
 
 #define PN532_SWHSU_READ_TIMEOUT						(1000)
 
-class PN532_SWHSU : public PN532Interface {
-public:
-    PN532_SWHSU(SoftwareSerial &serial);
-    
-    void begin();
-    void wakeup();
-    virtual int8_t writeCommand(const uint8_t *header, uint8_t hlen, const uint8_t *body = 0, uint8_t blen = 0);
-    int16_t readResponse(uint8_t buf[], uint8_t len, uint16_t timeout);
-    
-private:
+typedef struct {
+    pn532_interface interface;
     SoftwareSerial* _serial;
     uint8_t command;
-    
-    int8_t readAckFrame();
-    
-    int8_t receive(uint8_t *buf, int len, uint16_t timeout=PN532_SWHSU_READ_TIMEOUT);
-};
+} PN532_SWHSU;
+
+void pn532_swhsu_init(PN532_SWHSU *swhsu, SoftwareSerial &serial);
+void pn532_swhsu_begin(void *ctx);
+void pn532_swhsu_wakeup(void *ctx);
+int8_t pn532_swhsu_write_command(void *ctx, const uint8_t *header, uint8_t hlen, const uint8_t *body, uint8_t blen);
+int16_t pn532_swhsu_read_response(void *ctx, uint8_t buf[], uint8_t len, uint16_t timeout);
 
 #endif

--- a/pn532_interface.h
+++ b/pn532_interface.h
@@ -1,0 +1,24 @@
+#ifndef PN532_INTERFACE_H
+#define PN532_INTERFACE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct pn532_interface {
+    void (*begin)(void *context);
+    void (*wakeup)(void *context);
+    int8_t (*write_command)(void *context, const uint8_t *header, uint8_t hlen,
+                            const uint8_t *body, uint8_t blen);
+    int16_t (*read_response)(void *context, uint8_t *buf, uint8_t len,
+                             uint16_t timeout);
+    void *context;
+} pn532_interface;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PN532_INTERFACE_H */


### PR DESCRIPTION
## Summary
- define a new `pn532_interface` struct with function pointers
- remove C++ interface class from `PN532Interface.h`
- update `PN532`, `PN532_HSU`, and `PN532_SWHSU` to use the struct
- convert HSU and SWHSU implementations to plain functions

## Testing
- `g++ -c PN532.cpp` *(fails: `Arduino.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880b612549c83208191caf53751f0b9