### PR TITLE
Improve PN532 HAL timing and logging

### DIFF
--- a/PN532.cpp
+++ b/PN532.cpp
@@ -6,7 +6,6 @@
 */
 /**************************************************************************/
 
-#include "Arduino.h"
 #include "PN532.h"
 #include "PN532_debug.h"
 #include <string.h>
@@ -38,22 +37,10 @@ void PN532::begin()
 /**************************************************************************/
 void PN532::PrintHex(const uint8_t *data, const uint32_t numBytes)
 {
-#ifdef ARDUINO
     for (uint8_t i = 0; i < numBytes; i++) {
-        if (data[i] < 0x10) {
-            Serial.print(" 0");
-        } else {
-            Serial.print(' ');
-        }
-        Serial.print(data[i], HEX);
-    }
-    Serial.println("");
-#else
-    for (uint8_t i = 0; i < numBytes; i++) {
-        printf(" %2X", data[i]);
+        printf(" %02X", data[i]);
     }
     printf("\n");
-#endif
 }
 
 /**************************************************************************/
@@ -69,28 +56,8 @@ void PN532::PrintHex(const uint8_t *data, const uint32_t numBytes)
 /**************************************************************************/
 void PN532::PrintHexChar(const uint8_t *data, const uint32_t numBytes)
 {
-#ifdef ARDUINO
     for (uint8_t i = 0; i < numBytes; i++) {
-        if (data[i] < 0x10) {
-            Serial.print(" 0");
-        } else {
-            Serial.print(' ');
-        }
-        Serial.print(data[i], HEX);
-    }
-    Serial.print("    ");
-    for (uint8_t i = 0; i < numBytes; i++) {
-        char c = data[i];
-        if (c <= 0x1f || c > 0x7f) {
-            Serial.print('.');
-        } else {
-            Serial.print(c);
-        }
-    }
-    Serial.println("");
-#else
-    for (uint8_t i = 0; i < numBytes; i++) {
-        printf(" %2X", data[i]);
+        printf(" %02X", data[i]);
     }
     printf("    ");
     for (uint8_t i = 0; i < numBytes; i++) {
@@ -100,9 +67,8 @@ void PN532::PrintHexChar(const uint8_t *data, const uint32_t numBytes)
         } else {
             printf("%c", c);
         }
-        printf("\n");
     }
-#endif
+    printf("\n");
 }
 
 /**************************************************************************/

--- a/PN532_debug.h
+++ b/PN532_debug.h
@@ -1,15 +1,18 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
-//#define DEBUG
+//#define PN532_DEBUG
 
-#include "Arduino.h"
+#include <stdio.h>
 
-#ifdef DEBUG
-#define DMSG(args...)       Serial.print(args)
-#define DMSG_STR(str)       Serial.println(str)
-#define DMSG_HEX(num)       Serial.print(' '); Serial.print((num>>4)&0x0F, HEX); Serial.print(num&0x0F, HEX)
-#define DMSG_INT(num)       Serial.print(' '); Serial.print(num)
+#ifdef PN532_DEBUG
+#ifndef PN532_LOG
+#define PN532_LOG printf
+#endif
+#define DMSG(...)       PN532_LOG(__VA_ARGS__)
+#define DMSG_STR(str)   PN532_LOG("%s\n", str)
+#define DMSG_HEX(num)   PN532_LOG(" %02X", (uint8_t)(num))
+#define DMSG_INT(num)   PN532_LOG(" %d", (int)(num))
 #else
 #define DMSG(args...)
 #define DMSG_STR(str)


### PR DESCRIPTION
## Summary
- use `HAL_GetTick` based byte reads for UART timeouts
- replace Arduino debug macros with printf-based logging
- drop `Arduino.h` includes and update helper print functions

## Testing
- `gcc -c -I. -include /tmp/stub.h pn532_uart_hal.c`
- `gcc -c -I. -include /tmp/stub.h pn532.c`
- `g++ -c -I. -include /tmp/stub.h PN532.cpp` *(fails: too few arguments to function)*


------
https://chatgpt.com/codex/tasks/task_e_688183cb15188320a3da60a94fd3aba3