### PR TITLE
Define PN532_MIFARE_ISO14443A constant

### DIFF
--- a/pn532.h
+++ b/pn532.h
@@ -19,6 +19,9 @@
 #define PN532_GPIO_P32                      (2)
 #define PN532_GPIO_P34                      (4)
 
+/* Baud rate codes for pn532_read_passive_target_id() */
+#define PN532_MIFARE_ISO14443A              (0x00)
+
 typedef struct pn532 {
     pn532_interface *interface;
     uint8_t packet_buffer[64];


### PR DESCRIPTION
## Summary
- export `PN532_MIFARE_ISO14443A` in the main driver header

## Testing
- `gcc -I. -c examples/forward_uid.c` *(fails: `stm32f1xx_hal.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880b3f237a88320ad47c3a5bb8f89f1