### PR TITLE
Add uid length cap to pn532_read_passive_target_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ void nfc_poll(void)
     uint8_t uid[7];
     uint8_t uid_len;
     if (pn532_read_passive_target_id(&nfc, PN532_MIFARE_ISO14443A,
-                                     uid, &uid_len, 1000)) {
+                                     uid, &uid_len, sizeof(uid), 1000)) {
         // UID successfully read
     }
 }
@@ -86,7 +86,7 @@ void nfc_loop(void)
     uint8_t uid[7];
     uint8_t uid_len;
     if (pn532_read_passive_target_id(&nfc, PN532_MIFARE_ISO14443A,
-                                     uid, &uid_len, 1000)) {
+                                     uid, &uid_len, sizeof(uid), 1000)) {
         HAL_UART_Transmit(&huart2, uid, uid_len, HAL_MAX_DELAY);
     }
 }

--- a/examples/forward_uid.c
+++ b/examples/forward_uid.c
@@ -20,7 +20,8 @@ void nfc_loop(void)
 {
     uint8_t uid[7];
     uint8_t uid_len;
-    if (pn532_read_passive_target_id(&nfc, PN532_MIFARE_ISO14443A, uid, &uid_len, 1000)) {
+    if (pn532_read_passive_target_id(&nfc, PN532_MIFARE_ISO14443A,
+                                     uid, &uid_len, sizeof(uid), 1000)) {
         HAL_UART_Transmit(&huart2, uid, uid_len, HAL_MAX_DELAY);
     }
 }

--- a/pn532.c
+++ b/pn532.c
@@ -124,7 +124,9 @@ bool pn532_set_rf_field(pn532 *dev, uint8_t autoRFCA, uint8_t rFOnOff)
     return (0 < dev->interface->read_response(dev->interface->context, dev->packet_buffer, sizeof(dev->packet_buffer), 0));
 }
 
-bool pn532_read_passive_target_id(pn532 *dev, uint8_t cardbaudrate, uint8_t *uid, uint8_t *uidLength, uint16_t timeout)
+bool pn532_read_passive_target_id(pn532 *dev, uint8_t cardbaudrate,
+                                  uint8_t *uid, uint8_t *uidLength,
+                                  uint8_t uid_maxlen, uint16_t timeout)
 {
     dev->packet_buffer[0] = PN532_COMMAND_INLISTPASSIVETARGET;
     dev->packet_buffer[1] = 1;
@@ -139,6 +141,9 @@ bool pn532_read_passive_target_id(pn532 *dev, uint8_t cardbaudrate, uint8_t *uid
         return false;
     }
     *uidLength = dev->packet_buffer[5];
+    if (dev->packet_buffer[5] > uid_maxlen) {
+        return false;
+    }
     for (uint8_t i = 0; i < dev->packet_buffer[5]; i++) {
         uid[i] = dev->packet_buffer[6 + i];
     }

--- a/pn532.h
+++ b/pn532.h
@@ -38,6 +38,8 @@ uint8_t pn532_read_gpio(pn532 *dev);
 bool pn532_sam_config(pn532 *dev);
 bool pn532_set_passive_activation_retries(pn532 *dev, uint8_t maxRetries);
 bool pn532_set_rf_field(pn532 *dev, uint8_t autoRFCA, uint8_t rFOnOff);
-bool pn532_read_passive_target_id(pn532 *dev, uint8_t cardbaudrate, uint8_t *uid, uint8_t *uidLength, uint16_t timeout);
+bool pn532_read_passive_target_id(pn532 *dev, uint8_t cardbaudrate,
+                                  uint8_t *uid, uint8_t *uidLength,
+                                  uint8_t uid_maxlen, uint16_t timeout);
 
 #endif /* PN532_C_DRIVER_H */


### PR DESCRIPTION
## Summary
- bound UID copy in `pn532_read_passive_target_id`
- update header and example usage
- document extra parameter in README

## Testing
- `gcc -c pn532.c -I.`

------
https://chatgpt.com/codex/tasks/task_e_6881eeb40d608320a56640f8c612ce95